### PR TITLE
simpleenunu0.5.0対応

### DIFF
--- a/enusampler/Program.cs
+++ b/enusampler/Program.cs
@@ -203,10 +203,11 @@ class Program
             Console.WriteLine("TunedWavOutはture,falseで設定してください。");
             Environment.Exit(1);
         }
+
         if(TunedWavOut == false)
         {
             //TODO:pyファイルはリストを用意してその中に一致するものがあれば選択するようにする
-            pyfilePath = Path.Combine(pyfilePath,"simple_enunu040.py");
+            pyfilePath = Path.Combine(pyfilePath,"simple_enunu.py");
         }
         else
         {

--- a/enusampler/Program.cs
+++ b/enusampler/Program.cs
@@ -183,7 +183,15 @@ class Program
 
         if (string.IsNullOrEmpty(configuration["Environment:Python"]) || configuration["Environment:Python"] =="")
         {
-            pythonEnvPath = Path.Combine(configuration["Environment:ENUNU:Path"], @"python-3.9.13-embed-amd64\python.exe");
+            var pythonDir = Directory.GetDirectories(configuration["Environment:ENUNU:Path"], "*embed-amd64", SearchOption.TopDirectoryOnly);
+            if (pythonDir.Length == 0)
+            {
+                Console.WriteLine("Error: python env dir not found");
+                //Console.WriteLine("TunedWavOutはture,falseで設定してください。");
+                Environment.Exit(1);
+            }
+
+            pythonEnvPath = Path.Combine(pythonDir[0], @"python.exe");
             if (!File.Exists(pythonEnvPath))
             {
                 Console.WriteLine("Error: python.exe not found");
@@ -204,14 +212,24 @@ class Program
             Environment.Exit(1);
         }
 
-        if(TunedWavOut == false)
+        if(!TunedWavOut)
         {
             //TODO:pyファイルはリストを用意してその中に一致するものがあれば選択するようにする
             pyfilePath = Path.Combine(pyfilePath,"simple_enunu.py");
         }
         else
         {
-            pyfilePath = Path.Combine(pyfilePath, "simple_enunu040_TunedWavOut.py");
+
+            var tunedwavout = Directory.GetFiles(pyfilePath, "*TunedWavOut.py", SearchOption.TopDirectoryOnly);
+            if(tunedwavout.Length == 0)
+            {
+                Console.WriteLine("Error: tuned wav out file not found");
+                //Console.WriteLine("TunedWavOutはture,falseで設定してください。");
+                Environment.Exit(1);
+            }
+            Console.WriteLine(tunedwavout[0]);
+            pyfilePath = Path.Combine(pyfilePath, tunedwavout[0]);
+
         }
 
 
@@ -224,7 +242,14 @@ class Program
 
         var pyprocess = new PyProcessStart(pythonEnvPath, pyfilePath);
         var ustpath = CreateUst(file.Cachedir, ustForRender, file.Oto);
-        await pyprocess.EnunuStart(ustpath, tempWavPath);
+        var isBoolean = Boolean.TryParse(configuration["Environment:ENUNU:Legacy"], out bool legacy);
+        if(!isBoolean)
+        {
+            Console.WriteLine("Error:appsettings.json");
+            Console.WriteLine("Legacyはture,falseで設定してください。");
+            Environment.Exit(1);
+        }
+        await pyprocess.EnunuStart(ustpath, tempWavPath, legacy);
         ModBatchFile(batchFilePath);
 
         pyprocess.EnunuClose();

--- a/enusampler/PyProcessStart.cs
+++ b/enusampler/PyProcessStart.cs
@@ -27,7 +27,7 @@ namespace ENUNU_Engine
             throw new NotImplementedException();
         }
 
-        public async Task<bool> EnunuStart(string ustpath, string tempWavPath) {
+        public async Task<bool> EnunuStart(string ustpath, string tempWavPath,bool islegacy) {
             await Task.Run(() => {
                 //var current = Directory.GetParent(Assembly.GetExecutingAssembly().Location).ToString();
 
@@ -52,7 +52,15 @@ namespace ENUNU_Engine
                 //    play_wav: bool = True,
                 //    lf0: Any | None = None
                 //)->str
-                p.StartInfo.Arguments = $@"{srcPath} {ustpath} {tempWavPath}";// {_path} {_path.Replace(".ust", ".wav")}
+                if (islegacy)
+                {
+                    p.StartInfo.Arguments = $@"{srcPath} {ustpath} {tempWavPath}";
+                }
+                else
+                {
+                    //p.StartInfo.Arguments = $@"{srcPath} {ustpath} {tempWavPath}";
+                    p.StartInfo.Arguments = $@"{srcPath} --wav {tempWavPath} {ustpath} ";
+                }
                 p.Start();
                 p.WaitForExit();
             });

--- a/enusampler/appsettings.json
+++ b/enusampler/appsettings.json
@@ -1,9 +1,10 @@
 {
   "Environment": {
-    "Python": "",//オプション項目　利用するPython環境をパスで指定できます
+    "Python": "", //オプション項目　利用するPython環境をパスで指定できます
     "ENUNU": {
       "Path": "<SimpleEnunuのディレクトリを設定してください>", //例: "G:\SimpleEnunu-0.4.0"
-      "TunedWavOut": "false" // 利用する場合はtrueに編集
+      "TunedWavOut": "false", // 利用する場合はtrueに編集
+      "Legacy": "false" // 0.4.0以下のバージョンを利用する場合はtrueに編集"
     }
   }
 }


### PR DESCRIPTION
0.5.0以前のバージョンはレガシーとして対応
Pythonのパスを指定していないときにバージョン固定でパスを作成していた処理を修正

simpleenunuのバージョンに依存しないよう修正